### PR TITLE
Fix #66 remove camera translate for pcd export

### DIFF
--- a/imports/editor/3d/SsePCDLoader.js
+++ b/imports/editor/3d/SsePCDLoader.js
@@ -166,8 +166,10 @@ export default class SsePCDLoader {
 
                         pt = new THREE.Vector3(parseFloat(line[offset.x]), parseFloat(line[offset.y]), parseFloat(line[offset.z]));
 
-                        pt = pt.sub(camPosition);
-                        pt.applyQuaternion(camQuaternion);
+                        if (!this.serverMode) {
+                            pt = pt.sub(camPosition);
+                            pt.applyQuaternion(camQuaternion);
+                        }
 
                         item.x = pt.x;
                         position.push(pt.x);
@@ -222,8 +224,10 @@ export default class SsePCDLoader {
 
                         pt = new THREE.Vector3(x, y, z);
 
-                        pt = pt.sub(camPosition);
-                        pt.applyQuaternion(camQuaternion);
+                        if (!this.serverMode) {
+                            pt = pt.sub(camPosition);
+                            pt.applyQuaternion(camQuaternion);
+                        }
 
                         item.x = pt.x;
                         position.push(pt.x);
@@ -271,9 +275,11 @@ export default class SsePCDLoader {
 
                         pt = new THREE.Vector3(x, y, z);
 
-                        pt = pt.sub(camPosition);
-                        pt.applyQuaternion(camQuaternion);
-
+                        if (!this.serverMode) {
+                            pt = pt.sub(camPosition);
+                            pt.applyQuaternion(camQuaternion);
+                        }
+                        
                         item.x = pt.x;
                         position.push(pt.x);
 


### PR DESCRIPTION
The problem was, that the SsePCDLoader always translated the points into the camera space. That is not necessary for the PCD export because the points from the source PCD are already the correct real world coordinates.